### PR TITLE
Pose management

### DIFF
--- a/SmartDashboard/smartdash_config.xml
+++ b/SmartDashboard/smartdash_config.xml
@@ -1,86 +1,73 @@
 <xml version="1.0">
-  <dashboard>
-    <widget field="Alliance" type="String"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="171" y="260" />
-    </widget>
-    <widget field="RearRightAbsoluteMagnetOffset" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="356" y="152" />
-    </widget>
-    <widget field="RearLeftAbsoluteMagnetOffset" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="88" y="153" />
-    </widget>
-    <widget field="FrontRightAbsoluteMagnetOffset" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="354" y="62" />
-    </widget>
-    <widget field="FrontLeftAbsoluteMagnetOffset" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="85" y="64" />
-    </widget>
-    <widget field="Align Encoders" type="Command"
-      class="edu.wpi.first.smartdashboard.gui.elements.Command">
-      <location x="250" y="192" />
-    </widget>
-    <widget field="Auto Selector" type="String"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="0" y="260" />
-    </widget>
-    <widget field="GyroAngle" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="0" y="240" />
-    </widget>
-    <widget field="RearRightRelativeDrivePosition" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="286" y="338" />
-    </widget>
-    <widget field="RearRightAbsoluteTurningPosition" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="347" y="130" />
-    </widget>
-    <widget field="RearLeftRelativeDrivePosition" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="48" y="339" />
-    </widget>
-    <widget field="RearLeftAbsoluteTurningPosition" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="78" y="131" />
-    </widget>
-    <widget field="RearLeftRelativeTurningPosition" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="82" y="108" />
-    </widget>
-    <widget field="FrontRightRelativeDrivePosition" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="283" y="315" />
-    </widget>
-    <widget field="FrontRightAbsoluteTurningPosition" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="344" y="39" />
-    </widget>
-    <widget field="FrontRightRelativeTurningPosition" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="347" y="17" />
-    </widget>
-    <widget field="FrontLeftRelativeDrivePosition" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="47" y="316" />
-    </widget>
-    <widget field="FrontLeftRelativeTurningPosition" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="80" y="17" />
-    </widget>
-    <widget field="FrontLeftAbsoluteTurningPosition" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="76" y="40" />
-    </widget>
-    <widget field="RearRightRelativeTurningPosition" type="Number"
-      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-      <location x="350" y="107" />
-    </widget>
-  </dashboard>
-  <live-window>
-  </live-window>
+<dashboard>
+	<widget field="rotateField" type="Boolean" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="31" y="252"/>
+	</widget>
+	<widget field="fieldRelative" type="Boolean" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="25" y="275"/>
+	</widget>
+	<widget field="isRed" type="Boolean" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="56" y="230"/>
+	</widget>
+	<widget field="Auto" type="String" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="59" y="208"/>
+	</widget>
+	<widget field="RearRightAbsoluteMagnetOffset" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="356" y="152"/>
+	</widget>
+	<widget field="RearLeftAbsoluteMagnetOffset" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="88" y="153"/>
+	</widget>
+	<widget field="FrontRightAbsoluteMagnetOffset" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="354" y="62"/>
+	</widget>
+	<widget field="FrontLeftAbsoluteMagnetOffset" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="85" y="64"/>
+	</widget>
+	<widget field="Align Encoders" type="Command" class="edu.wpi.first.smartdashboard.gui.elements.Command">
+		<location x="250" y="192"/>
+	</widget>
+	<widget field="GyroAngle" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="232" y="240"/>
+	</widget>
+	<widget field="RearRightRelativeDrivePosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="286" y="338"/>
+	</widget>
+	<widget field="RearRightAbsoluteTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="347" y="130"/>
+	</widget>
+	<widget field="RearLeftRelativeDrivePosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="48" y="339"/>
+	</widget>
+	<widget field="RearLeftAbsoluteTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="78" y="131"/>
+	</widget>
+	<widget field="RearLeftRelativeTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="82" y="108"/>
+	</widget>
+	<widget field="FrontRightRelativeDrivePosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="283" y="315"/>
+	</widget>
+	<widget field="FrontRightAbsoluteTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="344" y="39"/>
+	</widget>
+	<widget field="FrontRightRelativeTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="347" y="17"/>
+	</widget>
+	<widget field="FrontLeftRelativeDrivePosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="47" y="316"/>
+	</widget>
+	<widget field="FrontLeftRelativeTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="80" y="17"/>
+	</widget>
+	<widget field="FrontLeftAbsoluteTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="76" y="40"/>
+	</widget>
+	<widget field="RearRightRelativeTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+		<location x="350" y="107"/>
+	</widget>
+</dashboard>
+<live-window>
+</live-window>
+	<hidden field="Field"/>
 </xml>

--- a/SmartDashboard/smartdash_config.xml
+++ b/SmartDashboard/smartdash_config.xml
@@ -1,73 +1,95 @@
 <xml version="1.0">
-<dashboard>
-	<widget field="rotateField" type="Boolean" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="31" y="252"/>
-	</widget>
-	<widget field="fieldRelative" type="Boolean" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="25" y="275"/>
-	</widget>
-	<widget field="isRed" type="Boolean" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="56" y="230"/>
-	</widget>
-	<widget field="Auto" type="String" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="59" y="208"/>
-	</widget>
-	<widget field="RearRightAbsoluteMagnetOffset" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="356" y="152"/>
-	</widget>
-	<widget field="RearLeftAbsoluteMagnetOffset" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="88" y="153"/>
-	</widget>
-	<widget field="FrontRightAbsoluteMagnetOffset" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="354" y="62"/>
-	</widget>
-	<widget field="FrontLeftAbsoluteMagnetOffset" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="85" y="64"/>
-	</widget>
-	<widget field="Align Encoders" type="Command" class="edu.wpi.first.smartdashboard.gui.elements.Command">
-		<location x="250" y="192"/>
-	</widget>
-	<widget field="GyroAngle" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="232" y="240"/>
-	</widget>
-	<widget field="RearRightRelativeDrivePosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="286" y="338"/>
-	</widget>
-	<widget field="RearRightAbsoluteTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="347" y="130"/>
-	</widget>
-	<widget field="RearLeftRelativeDrivePosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="48" y="339"/>
-	</widget>
-	<widget field="RearLeftAbsoluteTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="78" y="131"/>
-	</widget>
-	<widget field="RearLeftRelativeTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="82" y="108"/>
-	</widget>
-	<widget field="FrontRightRelativeDrivePosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="283" y="315"/>
-	</widget>
-	<widget field="FrontRightAbsoluteTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="344" y="39"/>
-	</widget>
-	<widget field="FrontRightRelativeTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="347" y="17"/>
-	</widget>
-	<widget field="FrontLeftRelativeDrivePosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="47" y="316"/>
-	</widget>
-	<widget field="FrontLeftRelativeTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="80" y="17"/>
-	</widget>
-	<widget field="FrontLeftAbsoluteTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="76" y="40"/>
-	</widget>
-	<widget field="RearRightRelativeTurningPosition" type="Number" class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
-		<location x="350" y="107"/>
-	</widget>
-</dashboard>
-<live-window>
-</live-window>
-	<hidden field="Field"/>
+  <dashboard>
+    <widget field="rotateField" type="Boolean"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="31" y="252" />
+    </widget>
+    <widget field="fieldRelative" type="Boolean"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="25" y="275" />
+    </widget>
+    <widget field="isRed" type="Boolean"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="56" y="230" />
+    </widget>
+    <widget field="Auto" type="String"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="59" y="208" />
+    </widget>
+    <widget field="RearRightAbsoluteMagnetOffset" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="356" y="152" />
+    </widget>
+    <widget field="RearLeftAbsoluteMagnetOffset" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="88" y="153" />
+    </widget>
+    <widget field="FrontRightAbsoluteMagnetOffset" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="354" y="62" />
+    </widget>
+    <widget field="FrontLeftAbsoluteMagnetOffset" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="85" y="64" />
+    </widget>
+    <widget field="Align Encoders" type="Command"
+      class="edu.wpi.first.smartdashboard.gui.elements.Command">
+      <location x="250" y="192" />
+    </widget>
+    <widget field="GyroAngle" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="232" y="240" />
+    </widget>
+    <widget field="RearRightRelativeDrivePosition" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="286" y="338" />
+    </widget>
+    <widget field="RearRightAbsoluteTurningPosition" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="347" y="130" />
+    </widget>
+    <widget field="RearLeftRelativeDrivePosition" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="48" y="339" />
+    </widget>
+    <widget field="RearLeftAbsoluteTurningPosition" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="78" y="131" />
+    </widget>
+    <widget field="RearLeftRelativeTurningPosition" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="82" y="108" />
+    </widget>
+    <widget field="FrontRightRelativeDrivePosition" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="283" y="315" />
+    </widget>
+    <widget field="FrontRightAbsoluteTurningPosition" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="344" y="39" />
+    </widget>
+    <widget field="FrontRightRelativeTurningPosition" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="347" y="17" />
+    </widget>
+    <widget field="FrontLeftRelativeDrivePosition" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="47" y="316" />
+    </widget>
+    <widget field="FrontLeftRelativeTurningPosition" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="80" y="17" />
+    </widget>
+    <widget field="FrontLeftAbsoluteTurningPosition" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="76" y="40" />
+    </widget>
+    <widget field="RearRightRelativeTurningPosition" type="Number"
+      class="edu.wpi.first.smartdashboard.gui.elements.TextBox">
+      <location x="350" y="107" />
+    </widget>
+  </dashboard>
+  <live-window>
+  </live-window>
+  <hidden field="Field" />
 </xml>

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -9,7 +9,7 @@ import edu.wpi.first.wpilibj.TimedRobot;
 
 public final class Constants {
 
-  public static enum Alliance {
+  public static enum AllianceColor {
     RED_ALLIANCE,
     BLUE_ALLIANCE
   }

--- a/src/main/java/frc/robot/drivetrain/Drivetrain.java
+++ b/src/main/java/frc/robot/drivetrain/Drivetrain.java
@@ -110,7 +110,7 @@ public class Drivetrain extends SubsystemBase {
     SmartDashboard.putBoolean("isRed", getRedAlliance());
     SmartDashboard.putNumber("GyroAngle", m_gyro.getRotation2d().getDegrees());
   }
-  
+
   /**
    * @param chassisSpeeds Robot-relative chassis speeds (x, y, theta)
    */
@@ -166,9 +166,10 @@ public class Drivetrain extends SubsystemBase {
   }
 
   public void resetHeading() {
-    Pose2d pose = getRedAlliance()
-      ? new Pose2d(getPose().getTranslation(), new Rotation2d(Math.PI))
-      : new Pose2d(getPose().getTranslation(), new Rotation2d());
+    Pose2d pose =
+        getRedAlliance()
+            ? new Pose2d(getPose().getTranslation(), new Rotation2d(Math.PI))
+            : new Pose2d(getPose().getTranslation(), new Rotation2d());
 
     m_odometry.resetPosition(m_gyro.getRotation2d(), getSwerveModulePositions(), pose);
   }

--- a/src/main/java/frc/robot/drivetrain/commands/Drive.java
+++ b/src/main/java/frc/robot/drivetrain/commands/Drive.java
@@ -4,6 +4,7 @@ package frc.robot.drivetrain.commands;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.drivetrain.Drivetrain;
@@ -14,7 +15,6 @@ public abstract class Drive extends Command {
   private double yDot;
   private double thetaDot;
   private boolean fieldRelative;
-  private boolean rotateField;
   private ChassisSpeeds chassisSpeeds;
 
   // The subsystem the command runs on
@@ -34,13 +34,16 @@ public abstract class Drive extends Command {
     yDot = getY() * DriveConstants.kMaxTranslationalVelocity;
     thetaDot = getTheta() * DriveConstants.kMaxRotationalVelocity;
     fieldRelative = fieldRelative();
-    rotateField = rotateField();
+
+    SmartDashboard.putBoolean("fieldRelative", fieldRelative);
+    SmartDashboard.putBoolean("rotateField", drivetrain.getFieldRotated());
 
     chassisSpeeds =
         fieldRelative
-            ? rotateField
+            ? drivetrain.getFieldRotated()
                 ? ChassisSpeeds.fromFieldRelativeSpeeds(
                     xDot, yDot, thetaDot, drivetrain.getHeading().rotateBy(new Rotation2d(Math.PI)))
+                    //xDot, yDot, thetaDot, drivetrain.getHeading())
                 : ChassisSpeeds.fromFieldRelativeSpeeds(
                     xDot, yDot, thetaDot, drivetrain.getHeading())
             : new ChassisSpeeds(xDot, yDot, thetaDot);
@@ -55,6 +58,4 @@ public abstract class Drive extends Command {
   public abstract double getTheta();
 
   public abstract boolean fieldRelative();
-
-  public abstract boolean rotateField();
 }

--- a/src/main/java/frc/robot/drivetrain/commands/Drive.java
+++ b/src/main/java/frc/robot/drivetrain/commands/Drive.java
@@ -43,7 +43,6 @@ public abstract class Drive extends Command {
             ? drivetrain.getFieldRotated()
                 ? ChassisSpeeds.fromFieldRelativeSpeeds(
                     xDot, yDot, thetaDot, drivetrain.getHeading().rotateBy(new Rotation2d(Math.PI)))
-                    //xDot, yDot, thetaDot, drivetrain.getHeading())
                 : ChassisSpeeds.fromFieldRelativeSpeeds(
                     xDot, yDot, thetaDot, drivetrain.getHeading())
             : new ChassisSpeeds(xDot, yDot, thetaDot);

--- a/src/main/java/frc/robot/drivetrain/commands/XBoxDrive.java
+++ b/src/main/java/frc/robot/drivetrain/commands/XBoxDrive.java
@@ -5,23 +5,20 @@ package frc.robot.drivetrain.commands;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.wpilibj.XboxController;
-import frc.robot.Constants.Alliance;
 import frc.robot.drivetrain.Drivetrain;
 
 public class XBoxDrive extends Drive {
 
   XboxController m_controller;
-  private Alliance alliance;
 
   // Slew rate limiters to make joystick inputs more gentle; 1/3 sec from 0 to 1.
   private final SlewRateLimiter m_xspeedLimiter = new SlewRateLimiter(3);
   private final SlewRateLimiter m_yspeedLimiter = new SlewRateLimiter(3);
   private final SlewRateLimiter m_rotLimiter = new SlewRateLimiter(3);
 
-  public XBoxDrive(Drivetrain subsystem, XboxController joysticks, Alliance alliance) {
+  public XBoxDrive(Drivetrain subsystem, XboxController joysticks, boolean rotateField) {
     super(subsystem);
     this.m_controller = joysticks;
-    this.alliance = alliance;
   }
 
   @Override
@@ -42,10 +39,5 @@ public class XBoxDrive extends Drive {
   @Override
   public boolean fieldRelative() {
     return m_controller.getLeftBumper();
-  }
-
-  @Override
-  public boolean rotateField() {
-    return (alliance == Alliance.RED_ALLIANCE);
   }
 }

--- a/src/main/java/frc/robot/drivetrain/commands/XBoxDrive.java
+++ b/src/main/java/frc/robot/drivetrain/commands/XBoxDrive.java
@@ -16,7 +16,7 @@ public class XBoxDrive extends Drive {
   private final SlewRateLimiter m_yspeedLimiter = new SlewRateLimiter(3);
   private final SlewRateLimiter m_rotLimiter = new SlewRateLimiter(3);
 
-  public XBoxDrive(Drivetrain subsystem, XboxController joysticks, boolean rotateField) {
+  public XBoxDrive(Drivetrain subsystem, XboxController joysticks) {
     super(subsystem);
     this.m_controller = joysticks;
   }

--- a/src/main/java/frc/robot/drivetrain/commands/ZorroDrive.java
+++ b/src/main/java/frc/robot/drivetrain/commands/ZorroDrive.java
@@ -4,19 +4,16 @@ package frc.robot.drivetrain.commands;
 
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.Joystick;
-import frc.robot.Constants.Alliance;
 import frc.robot.Constants.OIConstants;
 import frc.robot.drivetrain.Drivetrain;
 
 public class ZorroDrive extends Drive {
 
   Joystick m_controller;
-  private Alliance alliance;
 
-  public ZorroDrive(Drivetrain subsystem, Joystick joysticks, Alliance alliance) {
+  public ZorroDrive(Drivetrain subsystem, Joystick joysticks) {
     super(subsystem);
     this.m_controller = joysticks;
-    this.alliance = alliance;
   }
 
   @Override
@@ -40,10 +37,5 @@ public class ZorroDrive extends Drive {
   @Override
   public boolean fieldRelative() {
     return m_controller.getRawButton(OIConstants.kZorroEUp);
-  }
-
-  @Override
-  public boolean rotateField() {
-    return (alliance == Alliance.RED_ALLIANCE);
   }
 }

--- a/src/main/java/frc/robot/drivetrain/commands/ZorroDrive.java
+++ b/src/main/java/frc/robot/drivetrain/commands/ZorroDrive.java
@@ -18,19 +18,16 @@ public class ZorroDrive extends Drive {
 
   @Override
   public double getX() {
-    // return -m_controller.getRawAxis(OIConstants.kZorroRightYAxis);
     return -MathUtil.applyDeadband(m_controller.getRawAxis(OIConstants.kZorroRightYAxis), 0.05);
   }
 
   @Override
   public double getY() {
-    // return -m_controller.getRawAxis(OIConstants.kZorroRightXAxis);
     return -MathUtil.applyDeadband(m_controller.getRawAxis(OIConstants.kZorroRightXAxis), 0.05);
   }
 
   @Override
   public double getTheta() {
-    // return -m_controller.getRawAxis(OIConstants.kZorroLeftXAxis);
     return -MathUtil.applyDeadband(m_controller.getRawAxis(OIConstants.kZorroLeftXAxis), 0.05);
   }
 


### PR DESCRIPTION
Alliance managed in Drivetrain instead of RobotContainer, so it does not need to be passed into the drive command as a param

Pose is published to the dashboard. Can be viewed live using:
https://docs.wpilib.org/en/stable/docs/software/dashboards/glass/field2d-widget.html

Tested and working on the 2023 chassis. Test procedure:
1. Set alliance color
2. Restart robot code
3. Run driveFwd2m autonomous. Confirm pose is updated correctly on dashboard.
4. Enable in teleop and drive. Confirm pose is updated correctly on dashboard. Confirm stick direction makes sense.
5. Reset heading and continue to drive. Confirm pose is updated correctly on dashboard. Confirm stick direction makes sense.
6. Restart robot code and repeat steps 4 & 5, operating in teleop without first running autonomous.
7. Repeat entire procedure (steps 1-6) with the other alliance color.