### PR TITLE
Climber/power measurement

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -193,7 +193,7 @@ public final class Constants {
     public static final int kLeftMotorPort = 24;
     public static final int kRightMotorPort = 23;
 
-    public static final int kMotorCurrentLimit = 20;
+    public static final int kMotorCurrentLimit = 30;
     public static final double kMotorCurrentHardStop = 10.0;
 
     public static final double kP = 3.0;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -193,8 +193,8 @@ public final class Constants {
     public static final int kLeftMotorPort = 24;
     public static final int kRightMotorPort = 23;
 
-    public static final int kMotorCurrentLimit = 30;
-    public static final double kMotorCurrentHardStop = 5.0;
+    public static final int kMotorCurrentLimit = 60;
+    public static final double kMotorCurrentHardStop = 15.0;
 
     public static final double kP = 3.0;
     public static final double kI = 0.0;
@@ -219,7 +219,7 @@ public final class Constants {
         new TrapezoidProfile.Constraints(kSlowMaxVelocity, kSlowMaxAcceleration);
 
     public static final float kUpperLimit = -0.25f;
-    public static final float kLowerLimit = -15.0f;
+    public static final float kLowerLimit = -16.0f;
 
     public static final double kSeekPosition = 25.0;
     public static final double kHomePosition = -3.2;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -194,7 +194,7 @@ public final class Constants {
     public static final int kRightMotorPort = 23;
 
     public static final int kMotorCurrentLimit = 30;
-    public static final double kMotorCurrentHardStop = 10.0;
+    public static final double kMotorCurrentHardStop = 5.0;
 
     public static final double kP = 3.0;
     public static final double kI = 0.0;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -42,8 +42,6 @@ public class RobotContainer {
   private Joystick m_driver = new Joystick(OIConstants.kDriverControllerPort);
   private XboxController m_operator = new XboxController(OIConstants.kOperatorControllerPort);
 
-  
-
   // digital inputs for autonomous selection
   private final DigitalInput[] autonomousModes =
       new DigitalInput[AutoConstants.kAutonomousModeSelectorPorts.length];

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -31,16 +31,18 @@ import frc.robot.intake.Intake;
 
 public class RobotContainer {
 
+  private final PowerDistribution m_PowerDistribution = new PowerDistribution(1, ModuleType.kRev);
+
   private final Drivetrain m_swerve = new Drivetrain();
   private final Arm m_arm = new Arm();
   private final Intake m_intake = new Intake();
-  private final Climber m_climber = new Climber();
+  private final Climber m_climber = new Climber(m_PowerDistribution);
 
   private final EventLoop m_loop = new EventLoop();
   private Joystick m_driver = new Joystick(OIConstants.kDriverControllerPort);
   private XboxController m_operator = new XboxController(OIConstants.kOperatorControllerPort);
 
-  private final PowerDistribution m_PowerDistribution = new PowerDistribution(1, ModuleType.kRev);
+  
 
   // digital inputs for autonomous selection
   private final DigitalInput[] autonomousModes =

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -5,6 +5,8 @@ package frc.robot;
 import com.pathplanner.lib.commands.PathPlannerAuto;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.PowerDistribution;
+import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Axis;
 import edu.wpi.first.wpilibj.XboxController.Button;
@@ -37,6 +39,8 @@ public class RobotContainer {
   private final EventLoop m_loop = new EventLoop();
   private Joystick m_driver = new Joystick(OIConstants.kDriverControllerPort);
   private XboxController m_operator = new XboxController(OIConstants.kOperatorControllerPort);
+
+  private final PowerDistribution m_PowerDistribution = new PowerDistribution(1, ModuleType.kRev);
 
   // digital inputs for autonomous selection
   private final DigitalInput[] autonomousModes =
@@ -112,8 +116,8 @@ public class RobotContainer {
     //     .whileTrue(m_intake.createSetVoltageCommand(-12.0));
 
     // Moves note back in order to place in trap
-    new JoystickButton(m_operator, Button.kB.value)
-        .whileTrue(m_intake.createSetPositionCommand(-0.27));
+    // new JoystickButton(m_operator, Button.kB.value)
+    //     .whileTrue(m_intake.createSetPositionCommand(-0.27));
 
     // Gives note to teammates
     new JoystickButton(m_operator, Button.kBack.value)
@@ -141,11 +145,15 @@ public class RobotContainer {
   public void periodic() {
     m_loop.poll();
     updateSelectedAutonomous();
+
     if (m_autonomous != null) {
       SmartDashboard.putString("Auto", m_autonomous.getFilename());
     } else {
       SmartDashboard.putString("Auto", "Null");
     }
+
+    SmartDashboard.putNumber("PDHVoltage", m_PowerDistribution.getVoltage());
+    SmartDashboard.putNumber("PDHTotalCurrent", m_PowerDistribution.getTotalCurrent());
   }
 
   private class Autonomous {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -90,8 +90,8 @@ public class RobotContainer {
     // .whileTrue(m_climber.createDriveToCommand(ClimberConstants.kHomePosition));
     // .whileTrue(m_climber.createArcadeDriveCommand(m_operator));
     
-    new JoystickButton(m_operator,Button.kB.value)
-        .whileTrue(m_climber.createArcadeDriveCommand(m_operator));
+    // new JoystickButton(m_operator,Button.kB.value)
+    //     .whileTrue(m_climber.createArcadeDriveCommand(m_operator));
 
     // Raise and lower arm
     new JoystickButton(m_operator, Button.kA.value).onTrue(m_arm.createLowerArmCommand());
@@ -114,8 +114,8 @@ public class RobotContainer {
         .onlyIf(m_arm.isArmRaised()));
 
     // Reverses intake
-    // new JoystickButton(m_operator, Button.kB.value)
-    //     .whileTrue(m_intake.createSetVoltageCommand(-12.0));
+    new JoystickButton(m_operator, Button.kB.value)
+        .whileTrue(m_intake.createSetVoltageCommand(-12.0));
 
     // Moves note back in order to place in trap
     // new JoystickButton(m_operator, Button.kB.value)

--- a/src/main/java/frc/robot/climber/Climber.java
+++ b/src/main/java/frc/robot/climber/Climber.java
@@ -2,7 +2,6 @@ package frc.robot.climber;
 
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.ClimberConstants;
@@ -43,23 +42,8 @@ public class Climber extends SubsystemBase {
                 -xboxController.getRightY(), -xboxController.getLeftX()));
   }
 
-  // spotless:off
   @Override
   public void periodic() {
-    for (ClimberSide actuator : m_actuators) {
-      SmartDashboard.putNumber("Climber" + actuator.getName() + 
-        "Stroke", actuator.getPosition());
-      SmartDashboard.putNumber("Climber" + actuator.getName() + 
-        "MotorRotations", actuator.getPosition()/ClimberConstants.kPositionConversionFactor);
-      SmartDashboard.putBoolean("Climber" + actuator.getName() + 
-        "UpperSoftLimitState", actuator.getUpperSoftLimitSwtichState());
-      SmartDashboard.putBoolean("Climber" + actuator.getName() + 
-        "LowerSoftLimitState", actuator.getLowerSoftLimitSwtichState());
-      SmartDashboard.putNumber("Climber" + actuator.getName() + 
-        "Current", Math.signum(actuator.getVelocity()) * actuator.getCurrent());
-      SmartDashboard.putString("Climber" + actuator.getName() + 
-        "CalibrationState", actuator.getCalibrationState().name());
-    }
+    for (ClimberSide actuator : m_actuators) actuator.periodic();
   }
-  // spotless:on
 }

--- a/src/main/java/frc/robot/climber/Climber.java
+++ b/src/main/java/frc/robot/climber/Climber.java
@@ -5,20 +5,26 @@ import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.ClimberConstants;
+import edu.wpi.first.wpilibj.PowerDistribution;
 
 public class Climber extends SubsystemBase {
-  private final ClimberSide m_leftClimberSide =
-      new ClimberSide("Left", ClimberConstants.kLeftMotorPort);
-  private final ClimberSide m_rightClimberSide =
-      new ClimberSide("Right", ClimberConstants.kRightMotorPort);
+  
+  private ClimberSide[] m_actuators;
 
-  private ClimberSide[] m_actuators = {m_leftClimberSide, m_rightClimberSide};
+
+  private final PowerDistribution m_pdp;
 
   DifferentialDrive m_differentialDrive;
 
-  public Climber() {
+  public Climber(PowerDistribution pdp) {
+
+    this.m_pdp = pdp;
+    m_actuators[0] = new ClimberSide("Left", ClimberConstants.kLeftMotorPort, m_pdp);
+    m_actuators[1] = new ClimberSide("Right", ClimberConstants.kRightMotorPort, m_pdp);
+
     m_differentialDrive =
-        new DifferentialDrive(m_leftClimberSide::setPower, m_rightClimberSide::setPower);
+        new DifferentialDrive(m_actuators[0]::setPower, m_actuators[1]::setPower);
+
   }
 
   /**

--- a/src/main/java/frc/robot/climber/Climber.java
+++ b/src/main/java/frc/robot/climber/Climber.java
@@ -9,7 +9,7 @@ import edu.wpi.first.wpilibj.PowerDistribution;
 
 public class Climber extends SubsystemBase {
   
-  private ClimberSide[] m_actuators;
+  private ClimberSide[] m_actuators = new ClimberSide[2];
 
 
   private final PowerDistribution m_pdp;

--- a/src/main/java/frc/robot/climber/Climber.java
+++ b/src/main/java/frc/robot/climber/Climber.java
@@ -1,16 +1,15 @@
 package frc.robot.climber;
 
+import edu.wpi.first.wpilibj.PowerDistribution;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.ClimberConstants;
-import edu.wpi.first.wpilibj.PowerDistribution;
 
 public class Climber extends SubsystemBase {
-  
-  private ClimberSide[] m_actuators = new ClimberSide[2];
 
+  private ClimberSide[] m_actuators = new ClimberSide[2];
 
   private final PowerDistribution m_pdp;
 
@@ -22,9 +21,7 @@ public class Climber extends SubsystemBase {
     m_actuators[0] = new ClimberSide("Left", ClimberConstants.kLeftMotorPort, m_pdp);
     m_actuators[1] = new ClimberSide("Right", ClimberConstants.kRightMotorPort, m_pdp);
 
-    m_differentialDrive =
-        new DifferentialDrive(m_actuators[0]::setPower, m_actuators[1]::setPower);
-
+    m_differentialDrive = new DifferentialDrive(m_actuators[0]::setPower, m_actuators[1]::setPower);
   }
 
   /**

--- a/src/main/java/frc/robot/climber/ClimberSide.java
+++ b/src/main/java/frc/robot/climber/ClimberSide.java
@@ -13,8 +13,8 @@ import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants.ClimberConstants;
 import frc.robot.Constants.ClimberConstants.CalibrationState;
+import edu.wpi.first.wpilibj.PowerDistribution;
 import frc.robot.Constants.RobotConstants;
-import frc.robot.RobotContainer;
 
 public class ClimberSide {
 
@@ -35,9 +35,13 @@ public class ClimberSide {
 
   private CalibrationState m_calibrationState = CalibrationState.UNCALIBRATED;
 
-  public ClimberSide(String climberName, int climberMotorChannel) {
+  private final PowerDistribution m_pdp;
+
+  public ClimberSide(String climberName, int climberMotorChannel, PowerDistribution pdp) {
 
     this.climberName = climberName;
+
+    this.m_pdp = pdp;
 
     m_climberMover = new CANSparkMax(climberMotorChannel, MotorType.kBrushless);
 
@@ -158,12 +162,14 @@ public class ClimberSide {
         getName() + "MotorRotations", getPosition() / ClimberConstants.kPositionConversionFactor);
     SmartDashboard.putBoolean(getName() + "UpperSoftLimitState", getUpperSoftLimitSwtichState());
     SmartDashboard.putBoolean(getName() + "LowerSoftLimitState", getLowerSoftLimitSwtichState());
-    SmartDashboard.putNumber(getName() + "SparkMaxCurrent", addPolarity(getCurrent()));
-    // SmartDashboard.putNumber(getName() + "PDHCurrent", m_powerDistribtion ClimberConstants.kLeftMotorPort - 10);
+    SmartDashboard.putNumber(getName() + "SparkMaxCurrent",  addPolarity(getCurrent()));
+    SmartDashboard.putNumber(getName() + "PDHCurrent",  addPolarity(m_pdp.getCurrent(ClimberConstants.kLeftMotorPort - 10)));
     SmartDashboard.putString(getName() + "CalibrationState", getCalibrationState().name());
   }
 
   private double addPolarity(double value) {
     return value * Math.signum(m_climberMover.getAppliedOutput());
   }
+
+
 }

--- a/src/main/java/frc/robot/climber/ClimberSide.java
+++ b/src/main/java/frc/robot/climber/ClimberSide.java
@@ -10,9 +10,11 @@ import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.math.filter.Debouncer.DebounceType;
 import edu.wpi.first.math.filter.LinearFilter;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants.ClimberConstants;
 import frc.robot.Constants.ClimberConstants.CalibrationState;
 import frc.robot.Constants.RobotConstants;
+import frc.robot.RobotContainer;
 
 public class ClimberSide {
 
@@ -99,11 +101,11 @@ public class ClimberSide {
             > ClimberConstants.kMotorCurrentHardStop);
   }
 
-  public boolean getUpperSoftLimitSwtichState() {
+  private boolean getUpperSoftLimitSwtichState() {
     return m_climberMover.getFault(CANSparkBase.FaultID.kSoftLimitFwd);
   }
 
-  public boolean getLowerSoftLimitSwtichState() {
+  private boolean getLowerSoftLimitSwtichState() {
     return m_climberMover.getFault(CANSparkBase.FaultID.kSoftLimitRev);
   }
 
@@ -132,28 +134,36 @@ public class ClimberSide {
   /**
    * @return Position of climber actuator in inches
    */
-  public double getPosition() {
+  private double getPosition() {
     return m_climberRelativeEncoder.getPosition();
-  }
-
-  /**
-   * @return Velocity of climber actuator in in/s
-   */
-  public double getVelocity() {
-    return m_climberRelativeEncoder.getVelocity();
   }
 
   /**
    * @return Current in Amps, output of linear filter
    */
-  public double getCurrent() {
+  private double getCurrent() {
     return m_filter.calculate(m_climberMover.getOutputCurrent());
   }
 
   /**
    * @return Name of climber actuator
    */
-  public String getName() {
-    return climberName;
+  private String getName() {
+    return "Climber" + climberName;
+  }
+
+  public void periodic() {
+    SmartDashboard.putNumber(getName() + "Stroke", getPosition());
+    SmartDashboard.putNumber(
+        getName() + "MotorRotations", getPosition() / ClimberConstants.kPositionConversionFactor);
+    SmartDashboard.putBoolean(getName() + "UpperSoftLimitState", getUpperSoftLimitSwtichState());
+    SmartDashboard.putBoolean(getName() + "LowerSoftLimitState", getLowerSoftLimitSwtichState());
+    SmartDashboard.putNumber(getName() + "SparkMaxCurrent", addPolarity(getCurrent()));
+    // SmartDashboard.putNumber(getName() + "PDHCurrent", m_powerDistribtion ClimberConstants.kLeftMotorPort - 10);
+    SmartDashboard.putString(getName() + "CalibrationState", getCalibrationState().name());
+  }
+
+  private double addPolarity(double value) {
+    return value * Math.signum(m_climberMover.getAppliedOutput());
   }
 }

--- a/src/main/java/frc/robot/climber/ClimberSide.java
+++ b/src/main/java/frc/robot/climber/ClimberSide.java
@@ -22,6 +22,7 @@ public class ClimberSide {
 
   private final CANSparkMax m_climberMover;
   private final RelativeEncoder m_climberRelativeEncoder;
+  private final int motorChannel;
 
   private final ProfiledPIDController m_climberPIDController =
       new ProfiledPIDController(
@@ -30,7 +31,7 @@ public class ClimberSide {
           ClimberConstants.kD,
           ClimberConstants.rapidConstraints);
 
-  private LinearFilter m_filter = LinearFilter.singlePoleIIR(0.3, RobotConstants.kPeriod);
+  private LinearFilter m_filter = LinearFilter.singlePoleIIR(0.4, RobotConstants.kPeriod);
   private Debouncer m_debouncer = new Debouncer(0.05, DebounceType.kRising);
 
   private CalibrationState m_calibrationState = CalibrationState.UNCALIBRATED;
@@ -40,10 +41,11 @@ public class ClimberSide {
   public ClimberSide(String climberName, int climberMotorChannel, PowerDistribution pdp) {
 
     this.climberName = climberName;
+    this.motorChannel = climberMotorChannel;
 
     this.m_pdp = pdp;
 
-    m_climberMover = new CANSparkMax(climberMotorChannel, MotorType.kBrushless);
+    m_climberMover = new CANSparkMax(motorChannel, MotorType.kBrushless);
 
     m_climberMover.restoreFactoryDefaults();
 
@@ -101,7 +103,7 @@ public class ClimberSide {
 
   public boolean getCurrentSenseState() {
     return m_debouncer.calculate(
-        getPdhCurrent() > ClimberConstants.kMotorCurrentHardStop);
+        getSparkMaxCurrent() > ClimberConstants.kMotorCurrentHardStop);
   }
 
   private boolean getUpperSoftLimitSwtichState() {
@@ -149,7 +151,7 @@ public class ClimberSide {
   }
 
   private double getPdhCurrent(){
-    return m_pdp.getCurrent(ClimberConstants.kLeftMotorPort - 10);
+    return m_pdp.getCurrent(motorChannel-10);
   }
 
   /**

--- a/src/main/java/frc/robot/climber/ClimberSide.java
+++ b/src/main/java/frc/robot/climber/ClimberSide.java
@@ -145,8 +145,12 @@ public class ClimberSide {
   /**
    * @return Current in Amps, output of linear filter
    */
-  private double getCurrent() {
+  private double getSparkMaxCurrent() {
     return m_filter.calculate(m_climberMover.getOutputCurrent());
+  }
+
+  private double getPdhCurrent(){
+    return m_pdp.getCurrent(ClimberConstants.kLeftMotorPort - 10);
   }
 
   /**
@@ -162,8 +166,8 @@ public class ClimberSide {
         getName() + "MotorRotations", getPosition() / ClimberConstants.kPositionConversionFactor);
     SmartDashboard.putBoolean(getName() + "UpperSoftLimitState", getUpperSoftLimitSwtichState());
     SmartDashboard.putBoolean(getName() + "LowerSoftLimitState", getLowerSoftLimitSwtichState());
-    SmartDashboard.putNumber(getName() + "SparkMaxCurrent",  addPolarity(getCurrent()));
-    SmartDashboard.putNumber(getName() + "PDHCurrent",  addPolarity(m_pdp.getCurrent(ClimberConstants.kLeftMotorPort - 10)));
+    SmartDashboard.putNumber(getName() + "SparkMaxCurrent",  addPolarity(getSparkMaxCurrent()));
+    SmartDashboard.putNumber(getName() + "PDHCurrent",  addPolarity(getPdhCurrent()));
     SmartDashboard.putString(getName() + "CalibrationState", getCalibrationState().name());
   }
 

--- a/src/main/java/frc/robot/climber/ClimberSide.java
+++ b/src/main/java/frc/robot/climber/ClimberSide.java
@@ -101,8 +101,7 @@ public class ClimberSide {
 
   public boolean getCurrentSenseState() {
     return m_debouncer.calculate(
-        m_filter.calculate(m_climberMover.getOutputCurrent())
-            > ClimberConstants.kMotorCurrentHardStop);
+        getPdhCurrent() > ClimberConstants.kMotorCurrentHardStop);
   }
 
   private boolean getUpperSoftLimitSwtichState() {

--- a/src/main/java/frc/robot/climber/ClimberSide.java
+++ b/src/main/java/frc/robot/climber/ClimberSide.java
@@ -10,10 +10,10 @@ import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.math.filter.Debouncer.DebounceType;
 import edu.wpi.first.math.filter.LinearFilter;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
+import edu.wpi.first.wpilibj.PowerDistribution;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants.ClimberConstants;
 import frc.robot.Constants.ClimberConstants.CalibrationState;
-import edu.wpi.first.wpilibj.PowerDistribution;
 import frc.robot.Constants.RobotConstants;
 
 public class ClimberSide {
@@ -102,8 +102,7 @@ public class ClimberSide {
   }
 
   public boolean getCurrentSenseState() {
-    return m_debouncer.calculate(
-        getSparkMaxCurrent() > ClimberConstants.kMotorCurrentHardStop);
+    return m_debouncer.calculate(getSparkMaxCurrent() > ClimberConstants.kMotorCurrentHardStop);
   }
 
   private boolean getUpperSoftLimitSwtichState() {
@@ -150,8 +149,8 @@ public class ClimberSide {
     return m_filter.calculate(m_climberMover.getOutputCurrent());
   }
 
-  private double getPdhCurrent(){
-    return m_pdp.getCurrent(motorChannel-10);
+  private double getPdhCurrent() {
+    return m_pdp.getCurrent(motorChannel - 10);
   }
 
   /**
@@ -167,14 +166,12 @@ public class ClimberSide {
         getName() + "MotorRotations", getPosition() / ClimberConstants.kPositionConversionFactor);
     SmartDashboard.putBoolean(getName() + "UpperSoftLimitState", getUpperSoftLimitSwtichState());
     SmartDashboard.putBoolean(getName() + "LowerSoftLimitState", getLowerSoftLimitSwtichState());
-    SmartDashboard.putNumber(getName() + "SparkMaxCurrent",  addPolarity(getSparkMaxCurrent()));
-    SmartDashboard.putNumber(getName() + "PDHCurrent",  addPolarity(getPdhCurrent()));
+    SmartDashboard.putNumber(getName() + "SparkMaxCurrent", addPolarity(getSparkMaxCurrent()));
+    SmartDashboard.putNumber(getName() + "PDHCurrent", addPolarity(getPdhCurrent()));
     SmartDashboard.putString(getName() + "CalibrationState", getCalibrationState().name());
   }
 
   private double addPolarity(double value) {
-    return m_climberMover.getAppliedOutput() < 0.0
-      ? -value
-      : value;
+    return m_climberMover.getAppliedOutput() < 0.0 ? -value : value;
   }
 }

--- a/src/main/java/frc/robot/climber/ClimberSide.java
+++ b/src/main/java/frc/robot/climber/ClimberSide.java
@@ -173,8 +173,8 @@ public class ClimberSide {
   }
 
   private double addPolarity(double value) {
-    return value * Math.signum(m_climberMover.getAppliedOutput());
+    return m_climberMover.getAppliedOutput() < 0.0
+      ? -value
+      : value;
   }
-
-
 }


### PR DESCRIPTION
Added pdp object
https://docs.wpilib.org/en/stable/docs/software/can-devices/power-distribution-module.html

Partially answers #92 
Climbing draws 10-16 A of current upstream of the motor controller
Substantially raised (to 60 A) current limit downstream of motor; this is appropriate for a NEO motor per 
- https://docs.revrobotics.com/sparkmax/gs-sm/connect-a-spark-max-over-usb#limiting-current
- https://www.revrobotics.com/neo-brushless-motor-locked-rotor-testing/

It still may be a good idea to add the smart current limiting features
https://codedocs.revrobotics.com/java/com/revrobotics/cansparkbase#setSmartCurrentLimit(int,int,int)

Closes #93 
Output duty cycle is a more reliable indicator of the polarity of the current draw, instead of motor velocity